### PR TITLE
Fix error loading sprite139.sprite.gmx

### DIFF
--- a/YoYoCityEngine.gmx/YoYoCityEngine.project.gmx
+++ b/YoYoCityEngine.gmx/YoYoCityEngine.project.gmx
@@ -65,7 +65,6 @@
       </sprites>
       <sprites name="Minimap">
         <sprite>sprites\sprPoint</sprite>
-        <sprite>sprites\sprite139</sprite>
         <sprite>sprites\sprLosCone</sprite>
         <sprite>sprites\sprMiniMissionPointer</sprite>
         <sprite>sprites\sprMiniMissionTarget</sprite>


### PR DESCRIPTION
Fix error when project is loading.
Version of GMS : 1.3.1344 (beta channel)
![sprite139_error](https://cloud.githubusercontent.com/assets/3533296/3076555/de24a644-e3e9-11e3-95ac-3735ac9a1dc4.png)
